### PR TITLE
Fix orthosnap usage

### DIFF
--- a/phyloflow/main.py
+++ b/phyloflow/main.py
@@ -40,7 +40,7 @@ def run(
 
     All unrecognised arguments will be passed directly to Snakemake. Use `phyloflow --help-snakemake` to list all
     arguments accepted by Snakemake.
-    """
+    """  # noqa: W605
 
     snakefile = Path(__file__).parent / "workflow/Snakefile"
 

--- a/phyloflow/workflow/Snakefile
+++ b/phyloflow/workflow/Snakefile
@@ -52,4 +52,4 @@ onstart:
 
 rule all:
     input:
-        "results/alignment/alignment.fa",
+        "results/alignment/alignments.txt"

--- a/phyloflow/workflow/rules/alignment.smk
+++ b/phyloflow/workflow/rules/alignment.smk
@@ -89,8 +89,6 @@ def all_alignments(wildcards):
 rule list_alignments:
     """
     List path to alignment files into a single text file for use in PhyKIT.
-
-    NB I THINK THIS NEEDS TO USE A CHECKOUT TO GET ALL THE ALIGNMENT FILES.
     """
     output:
         "results/alignment/alignments.txt",

--- a/phyloflow/workflow/rules/intake.smk
+++ b/phyloflow/workflow/rules/intake.smk
@@ -58,8 +58,10 @@ rule extract_cds:
         else
             cp {input.file} {output}
         fi
-        """
 
+        # Sanitize the IDs
+        sed '/^>/s/;/_/g;s/ //g' {output} > {output}.tmp && mv {output}.tmp {output}
+        """
 
 rule add_taxon:
     """

--- a/phyloflow/workflow/rules/orthologs.smk
+++ b/phyloflow/workflow/rules/orthologs.smk
@@ -69,9 +69,8 @@ rule orthosnap:
         r"""
         orthosnap -f {input.fasta} -t {input.tree}
 
-        for f in {input.fasta}.orthosnap.*.fa; do
-            sed '/^>/s/\(.*\)_\([^|;_]*\)$/\1;\2/' $f > $f.bu && mv $f.bu $f
+        for f in {input.fasta}.orthosnap.*.fa; do  # N.B. This for loop just checks to ensure we have any matching files
+            cat {input.fasta}.orthosnap.*.fa > {output} || true
+            break
         done
-
-        cat {input.fasta}.orthosnap.*.fa > {output} || true
         """


### PR DESCRIPTION
This fixes the issues we discussed today, but we still end up with an empty orthosnap file for some of the orthogroups. These are created by Snakemake, not OrthoSnap. I think we will need to fix this with another checkpoint or other method but it's going to take a bit of playing. I'll try this tomorrow morning and keep you updated via this PR.