### PR TITLE
Suggestion: change to IQTree command

### DIFF
--- a/phyloflow/workflow/rules/supermatrix.smk
+++ b/phyloflow/workflow/rules/supermatrix.smk
@@ -63,7 +63,6 @@ rule iqtree:
         "iqtree2 -s {input} -bb 1000 -m TEST -ntmax {threads}"
 
 
-
 rule ascii_tree:
     """
     Displays the tree in ASCII format.


### PR DESCRIPTION
I propose changing the IQTree command. Specifically, removing the `redo` argument. IQTree has its own internal checkpoint system such that if a command is killed IQTree can quickly pick up from the last checkpoint. The `redo` argument in the IQTree command does not leverage the checkpoint because it forces IQTree to redo the analysis (that is, start from the beginning). This may be problematic if the time required for the tree inference step exceeds the maximum wall time a user has access to. Thus, I propose we change the IQTree command to `iqtree2 -s {input} -bb 1000 -m TEST -ntmax {threads}` from `iqtree2 -s {input} -bb 1000 -m TEST -ntmax {threads} -redo`.